### PR TITLE
add firefox binary path config

### DIFF
--- a/prop.properties
+++ b/prop.properties
@@ -6,6 +6,7 @@
 BrowserCoreType = 2
 
 # Drivers' path
+firefoxBinaryPath = D:\\Program Files\\Mozilla Firefox\\firefox.exe
 ChromeDriverPath = res/chromedriver_for_win.exe
 IEDriverPath = res/iedriver_32.exe
 

--- a/src/com/netease/dagger/BrowserEmulator.java
+++ b/src/com/netease/dagger/BrowserEmulator.java
@@ -27,7 +27,9 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriverBackedSelenium;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -64,7 +66,8 @@ public class BrowserEmulator {
 
 	private void setupBrowserCoreType(int type) {
 		if (type == 1) {
-			browserCore = new FirefoxDriver();
+			File pathBinary = new File(GlobalSettings.firefoxBinaryPath);
+			browserCore = new FirefoxDriver(new FirefoxBinary(pathBinary), new FirefoxProfile());
 			logger.info("Using Firefox");
 			return;
 		}

--- a/src/com/netease/dagger/GlobalSettings.java
+++ b/src/com/netease/dagger/GlobalSettings.java
@@ -16,7 +16,6 @@
  */
 package com.netease.dagger;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.util.Properties;
 
@@ -30,6 +29,8 @@ public class GlobalSettings {
 
 	public static int browserCoreType = Integer.parseInt(prop.getProperty("BrowserCoreType", "2"));
 
+	public static String firefoxBinaryPath = prop.getProperty("FirefoxBinaryPath", "D:\\Program Files\\Mozilla Firefox\\firefox.exe");
+	
 	public static String chromeDriverPath = prop.getProperty("ChromeDriverPath", "res/chromedriver_for_win.exe");
 //	public static String chromeDriverPath = "/Users/chenDoInG/Downloads/chromedriver_for_mac_64";
 	public static String ieDriverPath = prop.getProperty("IEDriverPath", "res/iedriver_32.exe");


### PR DESCRIPTION
当我使用dagger + firefox来做web自动化的时候，出现错误：
Exception in thread "main" org.openqa.selenium.WebDriverException: Cannot find firefox binary in PATH. Make sure firefox is installed. OS appears to be: VISTA

这是因为找不到firefox的exe地址（win平台），同时也没有一个地方去配置firefox路径，所以进行上上述修改，增加了firefox binary path配置项，同时修改BrowserEmulator中FirefoxDriver的构造，使用带GlobalSettings的配置参数构造，已经可以使用。
